### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,15 @@ portage
 
 My Gentoo portage overlay, with mainline fixes and custom ebuilds.
 
-Simply copy layman.xml to /etc/layman/overlays and add the repository using layman -a hhoffstaette
+Simply paste the following to `/etc/portage/repos.conf/hhoffstaette.conf`:
+
+```
+location = /var/db/repos/hhoffstaette
+sync-type = git
+sync-uri = https://github.com/hhoffstaette/portage.git
+```
+If you don't want to update the repository on every `emerge --sync` simply add
+
+```
+auto-sync = no
+```


### PR DESCRIPTION
Layman is dead. Simply use the standard portage repository configuration instead.